### PR TITLE
dependent premise broken into component models when removed

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -19,6 +19,7 @@
     <script type="module" src="src/js/tools/EditDependentPremiseButton.js"></script>
     <script type="module" src="src/js/tools/ManageTools.js"></script>
     <script type="module" src="src/js/tools/LinkButton.js"></script>
+    <script type="module" src="src/js/tools/RemoveDependentPremise.js"></script>
     
     <!-- MENU SCRIPTS -->
     <script type="module" src="src/js/menu/CreateArguments.js"></script>

--- a/public/src/js/tools/ManageTools.js
+++ b/public/src/js/tools/ManageTools.js
@@ -56,7 +56,7 @@ export function addDependentPremiseTools(element) {
     // boundary tool shows boundaries of element
     let boundaryTool = new joint.elementTools.Boundary();
     //remove tool deletes a rect
-    let removeButton = new joint.elementTools.Remove();
+    let removeDependentPremiseButton = new joint.elementTools.RemoveDependentPreimseButton();
     // link button
     let linkButton = new joint.elementTools.LinkButton();
     // dependent premise button
@@ -64,7 +64,7 @@ export function addDependentPremiseTools(element) {
     //the edit button is specific to dependent premise
     let editDependentPremiseButton = new joint.elementTools.EditDependentPremiseButton();
     let toolsView = new joint.dia.ToolsView({
-        tools: [boundaryTool, removeButton, linkButton, editDependentPremiseButton, combinePremiseButton]
+        tools: [boundaryTool, removeDependentPremiseButton, linkButton, editDependentPremiseButton, combinePremiseButton]
     });
     //element view is in charge of rendering the elements on the paper
     let elementView = element.findView(paper);

--- a/public/src/js/tools/RemoveDependentPremise.js
+++ b/public/src/js/tools/RemoveDependentPremise.js
@@ -1,0 +1,58 @@
+import { graph } from "../graph.js";
+import { addRectTools, addDependentPremiseTools } from "./ManageTools.js";
+const joint = window.joint;
+joint.elementTools.RemoveDependentPreimseButton = joint.elementTools.Button.extend({
+    name: "remove-dependent-premise-button",
+    options: {
+        markup: [{
+                tagName: "circle",
+                selector: "button",
+                attributes: {
+                    'r': 7,
+                    'fill': "red",
+                    'cursor': "pointer"
+                }
+            }, {
+                tagName: 'path',
+                selector: 'icon',
+                attributes: {
+                    //genuinely no idea what this is called but I used it to draw the arrow on the button
+                    'd': 'M -4 -1 0 4 M 0 4 4 -1 M 0 4 0 -4',
+                    'fill': 'none',
+                    'stroke': '#FFFFFF',
+                    'stroke-width': 2,
+                    'pointer-events': 'none'
+                }
+            }],
+        x: '0%',
+        y: '0',
+        offset: {
+            x: 0,
+            y: 0,
+        },
+        rotate: true,
+        action: function () {
+            let model = this.model;
+            console.log("dependent-premise-removed");
+            // add component models
+            let model1 = model.attributes.model1;
+            let model2 = model.attributes.model2;
+            model1.addTo(graph);
+            model2.addTo(graph);
+            if (model1.attributes.type === "argument" || model1.attributes.type === "objection") {
+                addRectTools(model1);
+            }
+            else {
+                addDependentPremiseTools(model1);
+            }
+            if (model2.attributes.type === "argument" || model2.attributes.type === "objection") {
+                addRectTools(model2);
+            }
+            else {
+                addDependentPremiseTools(model2);
+            }
+            //remove this dependent premise
+            model.remove();
+        }
+    }
+});

--- a/public/src/js/tools/RemoveDependetPremise.js
+++ b/public/src/js/tools/RemoveDependetPremise.js
@@ -1,0 +1,1 @@
+import { joint } from "../cdn";

--- a/public/src/ts/tools/ManageTools.ts
+++ b/public/src/ts/tools/ManageTools.ts
@@ -66,7 +66,7 @@ export function addDependentPremiseTools(element: joint.shapes.app.DependentPrem
   // boundary tool shows boundaries of element
   let boundaryTool = new joint.elementTools.Boundary();
   //remove tool deletes a rect
-  let removeButton = new joint.elementTools.Remove();
+  let removeDependentPremiseButton = new joint.elementTools.RemoveDependentPreimseButton();
   // link button
   let linkButton = new joint.elementTools.LinkButton();
   // dependent premise button
@@ -75,7 +75,7 @@ export function addDependentPremiseTools(element: joint.shapes.app.DependentPrem
   let editDependentPremiseButton = new joint.elementTools.EditDependentPremiseButton();
 
   let toolsView = new joint.dia.ToolsView({
-    tools: [boundaryTool, removeButton, linkButton, editDependentPremiseButton, combinePremiseButton]
+    tools: [boundaryTool, removeDependentPremiseButton, linkButton, editDependentPremiseButton, combinePremiseButton]
   });
 
   //element view is in charge of rendering the elements on the paper

--- a/public/src/ts/tools/RemoveDependentPremise.ts
+++ b/public/src/ts/tools/RemoveDependentPremise.ts
@@ -1,0 +1,67 @@
+import { elementTools } from "jointjs"
+import { graph } from "../graph.js"
+import { addRectTools, addDependentPremiseTools } from "./ManageTools.js"
+
+const joint = window.joint
+
+declare module "jointjs" {
+    namespace elementTools {
+        class RemoveDependentPreimseButton extends joint.elementTools.Button {
+
+        }
+    }
+}
+
+joint.elementTools.RemoveDependentPreimseButton = joint.elementTools.Button.extend({
+    name: "remove-dependent-premise-button",
+    options: {
+      markup: [{
+        tagName: "circle",
+        selector: "button",
+        attributes: {
+          'r': 7,
+          'fill': "red",
+          'cursor': "pointer"
+        }
+      }, {
+        tagName: 'path',
+        selector: 'icon',
+        attributes: {
+          //genuinely no idea what this is called but I used it to draw the arrow on the button
+          'd': 'M -4 -1 0 4 M 0 4 4 -1 M 0 4 0 -4',
+          'fill': 'none',
+          'stroke': '#FFFFFF',
+          'stroke-width': 2,
+          'pointer-events': 'none'
+        }   
+      }],
+      x: '0%',
+      y: '0',
+      offset: {
+        x: 0,
+        y: 0,
+      },
+      rotate: true,
+      action: function (this:any) {
+        let model = this.model;
+        console.log("dependent-premise-removed")
+        // add component models
+        let model1 = model.attributes.model1;
+        let model2 = model.attributes.model2;
+        model1.addTo(graph);
+        model2.addTo(graph);
+        if (model1.attributes.type === "argument" || model1.attributes.type === "objection") {
+            addRectTools(model1);
+        } else {
+            addDependentPremiseTools(model1);
+        }
+        if (model2.attributes.type === "argument" || model2.attributes.type === "objection") {
+           addRectTools(model2);
+        } else {
+            addDependentPremiseTools(model2);
+        }
+        //remove this dependent premise
+        model.remove();
+      }
+    }
+});


### PR DESCRIPTION
removing dependent premise now uses custom remove button with additional property of re-adding its component models to the graph. it should work with any length of nested dependent premise.