### PR TITLE
Dependent premise remove

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -19,6 +19,7 @@
     <script type="module" src="src/js/tools/EditDependentPremiseButton.js"></script>
     <script type="module" src="src/js/tools/ManageTools.js"></script>
     <script type="module" src="src/js/tools/LinkButton.js"></script>
+    <script type="module" src="src/js/tools/RemoveDependentPremise.js"></script>
     
     <!-- MENU SCRIPTS -->
     <script type="module" src="src/js/menu/CreateArguments.js"></script>

--- a/public/src/js/menu/SaveEditsButton.js
+++ b/public/src/js/menu/SaveEditsButton.js
@@ -10,10 +10,12 @@ export function saveRectEdits() {
     // Instead, you should use editModel.set() for most things
     // .set() takes two arguments
     let text = document.getElementById("rect-model-text").value;
+    console.log(text);
     let text_wrap = joint.util.breakText(text, { width: 90 });
+    console.log(text_wrap);
     let count = (text_wrap.match(/\n/g) || []).length;
     let new_height = 16 + 13 * (count);
-    editModel.set('attrs', { text: { text: text_wrap } });
+    editModel.attr('text/text', text_wrap);
     editModel.resize(editModel.attributes.size.width, new_height);
     console.log(editModel.attributes.attrs.text.text);
     //hide edit menu
@@ -24,25 +26,30 @@ export function saveDPEdits() {
     // left model edits
     let lefttext = document.getElementById("DP-model-left-text").value;
     let left_wrap = joint.util.breakText(lefttext, { width: 90 });
+    console.log(left_wrap);
     let left_count = (left_wrap.match(/\n/g) || []).length;
-    let left_height = 16 + 13 * (left_count);
-    editModel.attributes.model1.set('attrs', { text: { text: left_wrap } });
+    console.log(left_count);
+    let left_height = 16 + 16 * (left_count);
+    editModel.attributes.model1.attr('text/text', left_wrap);
     editModel.attributes.model1.resize(editModel.attributes.model1.attributes.size.width, left_height);
     console.log(editModel.attributes.model1.attributes.attrs.text.text);
     // right model edits
     let righttext = document.getElementById("DP-model-right-text").value;
     let right_wrap = joint.util.breakText(righttext, { width: 90 });
+    console.log(right_wrap);
     let right_count = (right_wrap.match(/\n/g) || []).length;
-    let right_height = 16 + 13 * (right_count);
-    editModel.attributes.model2.set('attrs', { text: { text: right_wrap } });
+    console.log(right_count);
+    let right_height = 16 + 16 * (right_count);
+    editModel.attributes.model2.attr('text/text', right_wrap);
     editModel.attributes.model2.resize(editModel.attributes.model2.attributes.size.width, right_height);
     console.log(editModel.attributes.model2.attributes.attrs.text.text);
     //now update actual DP shape
-    let height = Math.max(editModel.attributes.model1.attributes.size.height, editModel.attributes.model2.attributes.size.height);
+    let height = Math.max(left_height, right_height);
     let width = editModel.attributes.model1.attributes.size.width + editModel.attributes.model2.attributes.size.width + 36; //36 should be dependent on font size
-    editModel.resize(width, height);
     let combinedText = combineText(left_wrap, right_wrap);
-    editModel.set('attrs', { text: { text: combinedText } });
+    editModel.attr('text/text', combinedText);
+    editModel.resize(width, height);
+    console.log((height / 16) - 1);
     console.log(editModel.attributes.attrs.text.text);
     //hide edit menu
     editView.style.display = "none";

--- a/public/src/js/tools/ManageTools.js
+++ b/public/src/js/tools/ManageTools.js
@@ -56,7 +56,7 @@ export function addDependentPremiseTools(element) {
     // boundary tool shows boundaries of element
     let boundaryTool = new joint.elementTools.Boundary();
     //remove tool deletes a rect
-    let removeButton = new joint.elementTools.Remove();
+    let removeDependentPremiseButton = new joint.elementTools.RemoveDependentPreimseButton();
     // link button
     let linkButton = new joint.elementTools.LinkButton();
     // dependent premise button
@@ -64,7 +64,7 @@ export function addDependentPremiseTools(element) {
     //the edit button is specific to dependent premise
     let editDependentPremiseButton = new joint.elementTools.EditDependentPremiseButton();
     let toolsView = new joint.dia.ToolsView({
-        tools: [boundaryTool, removeButton, linkButton, editDependentPremiseButton, combinePremiseButton]
+        tools: [boundaryTool, removeDependentPremiseButton, linkButton, editDependentPremiseButton, combinePremiseButton]
     });
     //element view is in charge of rendering the elements on the paper
     let elementView = element.findView(paper);

--- a/public/src/js/tools/RemoveDependentPremise.js
+++ b/public/src/js/tools/RemoveDependentPremise.js
@@ -39,6 +39,8 @@ joint.elementTools.RemoveDependentPreimseButton = joint.elementTools.Button.exte
             let model2 = model.attributes.model2;
             model1.addTo(graph);
             model2.addTo(graph);
+            console.log(model1);
+            console.log(model2);
             if (model1.attributes.type === "argument" || model1.attributes.type === "objection") {
                 addRectTools(model1);
             }

--- a/public/src/js/tools/RemoveDependentPremise.js
+++ b/public/src/js/tools/RemoveDependentPremise.js
@@ -1,0 +1,58 @@
+import { graph } from "../graph.js";
+import { addRectTools, addDependentPremiseTools } from "./ManageTools.js";
+const joint = window.joint;
+joint.elementTools.RemoveDependentPreimseButton = joint.elementTools.Button.extend({
+    name: "remove-dependent-premise-button",
+    options: {
+        markup: [{
+                tagName: "circle",
+                selector: "button",
+                attributes: {
+                    'r': 7,
+                    'fill': "red",
+                    'cursor': "pointer"
+                }
+            }, {
+                tagName: 'path',
+                selector: 'icon',
+                attributes: {
+                    //genuinely no idea what this is called but I used it to draw the arrow on the button
+                    'd': 'M -4 -1 0 4 M 0 4 4 -1 M 0 4 0 -4',
+                    'fill': 'none',
+                    'stroke': '#FFFFFF',
+                    'stroke-width': 2,
+                    'pointer-events': 'none'
+                }
+            }],
+        x: '0%',
+        y: '0',
+        offset: {
+            x: 0,
+            y: 0,
+        },
+        rotate: true,
+        action: function () {
+            let model = this.model;
+            console.log("dependent-premise-removed");
+            // add component models
+            let model1 = model.attributes.model1;
+            let model2 = model.attributes.model2;
+            model1.addTo(graph);
+            model2.addTo(graph);
+            if (model1.attributes.type === "argument" || model1.attributes.type === "objection") {
+                addRectTools(model1);
+            }
+            else {
+                addDependentPremiseTools(model1);
+            }
+            if (model2.attributes.type === "argument" || model2.attributes.type === "objection") {
+                addRectTools(model2);
+            }
+            else {
+                addDependentPremiseTools(model2);
+            }
+            //remove this dependent premise
+            model.remove();
+        }
+    }
+});

--- a/public/src/js/tools/RemoveDependetPremise.js
+++ b/public/src/js/tools/RemoveDependetPremise.js
@@ -1,0 +1,1 @@
+import { joint } from "../cdn";

--- a/public/src/ts/menu/SaveEditsButton.ts
+++ b/public/src/ts/menu/SaveEditsButton.ts
@@ -11,10 +11,12 @@ export function saveRectEdits() {
   // Instead, you should use editModel.set() for most things
   // .set() takes two arguments
   let text = (document.getElementById("rect-model-text")as HTMLTextAreaElement).value;
+  console.log(text);
   let text_wrap = joint.util.breakText(text, {width: 90})
+  console.log(text_wrap)
   let count = (text_wrap.match(/\n/g) || []).length;
   let new_height = 16 + 13*(count)
-  editModel.set('attrs', {text: {text: text_wrap}});
+  editModel.attr('text/text', text_wrap);
   editModel.resize(editModel.attributes.size.width, new_height);
   console.log(editModel.attributes.attrs.text.text)
   
@@ -29,27 +31,32 @@ export function saveDPEdits() {
   // left model edits
   let lefttext = (document.getElementById("DP-model-left-text") as HTMLTextAreaElement).value;
   let left_wrap = joint.util.breakText(lefttext, {width: 90})
-  let left_count = (left_wrap.match(/\n/g) || []).length; 
-  let left_height = 16 + 13*(left_count)
-  editModel.attributes.model1.set('attrs', {text: {text: left_wrap}});
+  console.log(left_wrap)
+  let left_count = (left_wrap.match(/\n/g) || []).length;
+  console.log(left_count) 
+  let left_height = 16 + 16*(left_count)
+  editModel.attributes.model1.attr('text/text', left_wrap);
   editModel.attributes.model1.resize(editModel.attributes.model1.attributes.size.width, left_height);
   console.log(editModel.attributes.model1.attributes.attrs.text.text);
   
   // right model edits
   let righttext = (document.getElementById("DP-model-right-text") as HTMLTextAreaElement).value;
   let right_wrap = joint.util.breakText(righttext, {width: 90})
+  console.log(right_wrap)
   let right_count = (right_wrap.match(/\n/g) || []).length; 
-  let right_height = 16 + 13*(right_count);
-  editModel.attributes.model2.set('attrs', {text: {text: right_wrap}});
+  console.log(right_count)
+  let right_height = 16 + 16*(right_count);
+  editModel.attributes.model2.attr('text/text', right_wrap);
   editModel.attributes.model2.resize(editModel.attributes.model2.attributes.size.width, right_height);
   console.log(editModel.attributes.model2.attributes.attrs.text.text);
 
   //now update actual DP shape
-  let height = Math.max(editModel.attributes.model1.attributes.size.height, editModel.attributes.model2.attributes.size.height);
+  let height = Math.max(left_height, right_height);
   let width = editModel.attributes.model1.attributes.size.width + editModel.attributes.model2.attributes.size.width + 36; //36 should be dependent on font size
-  editModel.resize(width, height);
   let combinedText = combineText(left_wrap, right_wrap);
-  editModel.set('attrs', {text: {text: combinedText}})
+  editModel.attr('text/text', combinedText)
+  editModel.resize(width, height);
+  console.log((height/16) - 1)
   console.log(editModel.attributes.attrs.text.text)
   
   //hide edit menu

--- a/public/src/ts/tools/ManageTools.ts
+++ b/public/src/ts/tools/ManageTools.ts
@@ -66,7 +66,7 @@ export function addDependentPremiseTools(element: joint.shapes.app.DependentPrem
   // boundary tool shows boundaries of element
   let boundaryTool = new joint.elementTools.Boundary();
   //remove tool deletes a rect
-  let removeButton = new joint.elementTools.Remove();
+  let removeDependentPremiseButton = new joint.elementTools.RemoveDependentPreimseButton();
   // link button
   let linkButton = new joint.elementTools.LinkButton();
   // dependent premise button
@@ -75,7 +75,7 @@ export function addDependentPremiseTools(element: joint.shapes.app.DependentPrem
   let editDependentPremiseButton = new joint.elementTools.EditDependentPremiseButton();
 
   let toolsView = new joint.dia.ToolsView({
-    tools: [boundaryTool, removeButton, linkButton, editDependentPremiseButton, combinePremiseButton]
+    tools: [boundaryTool, removeDependentPremiseButton, linkButton, editDependentPremiseButton, combinePremiseButton]
   });
 
   //element view is in charge of rendering the elements on the paper

--- a/public/src/ts/tools/RemoveDependentPremise.ts
+++ b/public/src/ts/tools/RemoveDependentPremise.ts
@@ -50,6 +50,8 @@ joint.elementTools.RemoveDependentPreimseButton = joint.elementTools.Button.exte
         let model2 = model.attributes.model2;
         model1.addTo(graph);
         model2.addTo(graph);
+        console.log(model1)
+        console.log(model2)
         if (model1.attributes.type === "argument" || model1.attributes.type === "objection") {
             addRectTools(model1);
         } else {

--- a/public/src/ts/tools/RemoveDependentPremise.ts
+++ b/public/src/ts/tools/RemoveDependentPremise.ts
@@ -1,0 +1,67 @@
+import { elementTools } from "jointjs"
+import { graph } from "../graph.js"
+import { addRectTools, addDependentPremiseTools } from "./ManageTools.js"
+
+const joint = window.joint
+
+declare module "jointjs" {
+    namespace elementTools {
+        class RemoveDependentPreimseButton extends joint.elementTools.Button {
+
+        }
+    }
+}
+
+joint.elementTools.RemoveDependentPreimseButton = joint.elementTools.Button.extend({
+    name: "remove-dependent-premise-button",
+    options: {
+      markup: [{
+        tagName: "circle",
+        selector: "button",
+        attributes: {
+          'r': 7,
+          'fill': "red",
+          'cursor': "pointer"
+        }
+      }, {
+        tagName: 'path',
+        selector: 'icon',
+        attributes: {
+          //genuinely no idea what this is called but I used it to draw the arrow on the button
+          'd': 'M -4 -1 0 4 M 0 4 4 -1 M 0 4 0 -4',
+          'fill': 'none',
+          'stroke': '#FFFFFF',
+          'stroke-width': 2,
+          'pointer-events': 'none'
+        }   
+      }],
+      x: '0%',
+      y: '0',
+      offset: {
+        x: 0,
+        y: 0,
+      },
+      rotate: true,
+      action: function (this:any) {
+        let model = this.model;
+        console.log("dependent-premise-removed")
+        // add component models
+        let model1 = model.attributes.model1;
+        let model2 = model.attributes.model2;
+        model1.addTo(graph);
+        model2.addTo(graph);
+        if (model1.attributes.type === "argument" || model1.attributes.type === "objection") {
+            addRectTools(model1);
+        } else {
+            addDependentPremiseTools(model1);
+        }
+        if (model2.attributes.type === "argument" || model2.attributes.type === "objection") {
+           addRectTools(model2);
+        } else {
+            addDependentPremiseTools(model2);
+        }
+        //remove this dependent premise
+        model.remove();
+      }
+    }
+});


### PR DESCRIPTION
Added ability for dependent premises to be deconstructed into their component elements when removed using a custom button.

Also fixed a bug related to element resizing when text is changed, as well as an issue causing the loss of other attributes when text is changed.