### PR TITLE
Fix circular structure caused by dependent premise

### DIFF
--- a/public/src/js/DependentPremise.js
+++ b/public/src/js/DependentPremise.js
@@ -18,7 +18,7 @@ const DependentPremiseRect = joint.shapes.standard.Rectangle.define("app.Depende
     link_color: "green",
     weight: "1",
     type: "dependent-premise",
-    models: []
+    props: []
     // ---
 });
 Object.assign(joint.shapes, {
@@ -29,31 +29,31 @@ Object.assign(joint.shapes, {
 //class definition
 export class DependentPremise {
     constructor(config) {
-        let rect1 = config.rect1.clone();
-        let rect2 = config.rect2.clone();
-        let models = [];
-        if (rect1.attributes.type === "dependent-premise") {
-            models.push(...rect1.attributes.models);
+        let props1 = Object.assign({}, config.props1);
+        let props2 = Object.assign({}, config.props2);
+        let props = [];
+        if (props1.type === "dependent-premise") {
+            props.push(...props1.props);
         }
         else {
-            models.push(rect1);
+            props.push(props1);
         }
-        if (rect2.attributes.type === "dependent-premise") {
-            models.push(...rect2.attributes.models);
+        if (props2.type === "dependent-premise") {
+            props.push(...props2.props);
         }
         else {
-            models.push(rect2);
+            props.push(props2);
         }
-        console.log("models", models);
+        console.log("props", props);
         //set size
-        let width = rect1.attributes.size.width + rect2.attributes.size.width;
-        let height = Math.max(rect1.attributes.size.height, rect2.attributes.size.height);
+        let width = props1.size.width + props2.size.width;
+        let height = Math.max(props1.size.height, props2.size.height);
         // set position (average position of two rects)
-        let x = (rect1.attributes.position.x + rect2.attributes.position.x) / 2;
-        let y = (rect1.attributes.position.y + rect2.attributes.position.y) / 2;
+        let x = (props1.position.x + props2.position.x) / 2;
+        let y = (props1.position.y + props2.position.y) / 2;
         //text wrap for both
-        let text_wrap1 = rect1.attributes.attrs.text.text;
-        let text_wrap2 = rect2.attributes.attrs.text.text;
+        let text_wrap1 = props1.attrs.text.text;
+        let text_wrap2 = props2.attrs.text.text;
         //generate new text string for display
         let combined_text = combineText(text_wrap1, text_wrap2);
         // define weight
@@ -92,9 +92,9 @@ export class DependentPremise {
             link_color: config.link_color,
             weight: config.weight,
             type: config.type,
-            models: models
+            props: props
         });
-        console.log(this.rect);
+        console.log("NEW DEPENDENT PREMISE", this.rect);
     }
 }
 export function combineText(text1, text2) {

--- a/public/src/js/main.js
+++ b/public/src/js/main.js
@@ -1,7 +1,7 @@
 /* global joint createDependentPremise */
 // const joint = window.joint;
 import { saveEdits } from './menu/SaveEditsButton.js';
-import { createArgument, createObjection, createDependentPremise } from './menu/CreateArguments.js';
+import { createArgument, createObjection } from './menu/CreateArguments.js';
 // this is built on Joint.js, an open source library. It handles a lot of the
 // fundamental pieces for us on the back end, we have to implement the front end / interface
 // to interact with it
@@ -46,7 +46,7 @@ paperContainer.addEventListener("drop", (event) => {
 });
 const editContainer = $('#edit-container');
 editContainer.hide();
-let arg1 = createArgument(100, 100);
-let arg2 = createArgument(300, 100);
-//testing
-let test = createDependentPremise(arg1.rect, arg2.rect);
+// let arg1 = createArgument(100, 100);
+// let arg2 = createArgument(300, 100);
+// //testing
+// let test = createDependentPremise(arg1.rect, arg2.rect);

--- a/public/src/js/menu/CreateArguments.js
+++ b/public/src/js/menu/CreateArguments.js
@@ -5,13 +5,13 @@ import { graph } from '../graph.js';
 import { Argument } from '../Argument.js';
 import { DependentPremise } from '../DependentPremise.js';
 //when new-argument-button is clicked
-export function createArgument(x, y, props = {}) {
+export function createArgument(x, y) {
     //creating new rect (Joint.js object)
     const new_rect = new Argument({
-        x: props.x || x,
-        y: props.y || y,
-        text: (props.attrs ? props.text.text : (props.text || "Argument")),
-        type: props.type || "argument",
+        x: x,
+        y: y,
+        text: "Argument",
+        type: "argument",
         body_color: color.argument.bodyColor,
         text_color: color.argument.textColor,
         stroke: color.argument.stroke,
@@ -25,13 +25,13 @@ export function createArgument(x, y, props = {}) {
     return new_rect;
 }
 //when objection-button is clicked
-export function createObjection(x, y, props = {}) {
+export function createObjection(x, y) {
     //creating new rect (Joint.js object)
     const new_rect = new Argument({
-        x: props.x || x,
-        y: props.y || y,
-        text: props.attrs.text.text || props.text || "Objection",
-        type: props.type || "objection",
+        x: x,
+        y: y,
+        text: "Objection",
+        type: "objection",
         body_color: color.objection.bodyColor,
         text_color: color.objection.textColor,
         stroke: color.objection.stroke,
@@ -64,6 +64,5 @@ export function createDependentPremise(rect1, rect2) {
     new_dependent_premise.rect.addTo(graph);
     //adds the buttons to each rect
     addDependentPremiseTools(new_dependent_premise.rect);
-    console.log(new_dependent_premise);
     return new_dependent_premise;
 }

--- a/public/src/js/menu/CreateArguments.js
+++ b/public/src/js/menu/CreateArguments.js
@@ -5,13 +5,13 @@ import { graph } from '../graph.js';
 import { Argument } from '../Argument.js';
 import { DependentPremise } from '../DependentPremise.js';
 //when new-argument-button is clicked
-export function createArgument(x, y) {
+export function createArgument(x, y, props = {}) {
     //creating new rect (Joint.js object)
     const new_rect = new Argument({
-        x: x,
-        y: y,
-        text: "Argument",
-        type: "argument",
+        x: props.x || x,
+        y: props.y || y,
+        text: (props.attrs ? props.text.text : (props.text || "Argument")),
+        type: props.type || "argument",
         body_color: color.argument.bodyColor,
         text_color: color.argument.textColor,
         stroke: color.argument.stroke,
@@ -25,13 +25,13 @@ export function createArgument(x, y) {
     return new_rect;
 }
 //when objection-button is clicked
-export function createObjection(x, y) {
+export function createObjection(x, y, props = {}) {
     //creating new rect (Joint.js object)
     const new_rect = new Argument({
-        x: x,
-        y: y,
-        text: "Objection",
-        type: "objection",
+        x: props.x || x,
+        y: props.y || y,
+        text: props.attrs.text.text || props.text || "Objection",
+        type: props.type || "objection",
         body_color: color.objection.bodyColor,
         text_color: color.objection.textColor,
         stroke: color.objection.stroke,
@@ -47,8 +47,8 @@ export function createObjection(x, y) {
 export function createDependentPremise(rect1, rect2) {
     //creating new rect (Joint.js object)
     let new_dependent_premise = new DependentPremise({
-        rect1: rect1,
-        rect2: rect2,
+        props1: rect1.attributes,
+        props2: rect2.attributes,
         x: 100,
         y: 100,
         text: "A dependent premise",
@@ -64,5 +64,6 @@ export function createDependentPremise(rect1, rect2) {
     new_dependent_premise.rect.addTo(graph);
     //adds the buttons to each rect
     addDependentPremiseTools(new_dependent_premise.rect);
+    console.log(new_dependent_premise);
     return new_dependent_premise;
 }

--- a/public/src/js/menu/SaveEditsButton.js
+++ b/public/src/js/menu/SaveEditsButton.js
@@ -10,19 +10,16 @@ export function saveEdits() {
     let heights = num_lines.map(lines => 16 + 13 * lines);
     if (editModel.attributes.type === "dependent-premise") {
         //save new text and adjust size on each model in dependent premise
-        editModel.attributes.models.forEach((model, index) => {
-            model.attr('text/text', text_wraps[index]);
-            model.resize(model.attributes.size.width, heights[index]);
-            console.log(model.attributes.attrs.text.text);
+        editModel.attributes.props.forEach((propObj, index) => {
+            propObj.attrs.text.text = text_wraps[index];
+            propObj.size.height = heights[index];
         });
         let max_height = Math.max(...heights);
         //the 36 is dependent on font-size!!
-        let width = 36 + editModel.attributes.models.reduce((total, model) => total + model.attributes.size.width, 0);
+        let width = 36 + editModel.attributes.props.reduce((total, propObj) => total + propObj.size.width, 0);
         let combinedText = text_wraps.slice(1).reduce((total, current) => {
-            //skip first one
             return combineText(total, current);
         }, text_wraps[0]);
-        //let combinedText = combineText(left_wrap, right_wrap);
         editModel.attr('text/text', combinedText);
         editModel.resize(width, max_height);
         // console.log((height/16) - 1)

--- a/public/src/js/tools/EditButton.js
+++ b/public/src/js/tools/EditButton.js
@@ -94,9 +94,9 @@ joint.elementTools.EditDependentPremiseButton = joint.elementTools.Button.extend
             console.log("editModel", editModel);
             const form = $('#edit-form');
             form.empty();
-            editModel.attributes.models.forEach((model, index) => {
+            editModel.attributes.props.forEach((propObj, index) => {
                 form.append(`<label class="menu-text">Edit Argument ${index + 1} Text:</label>`);
-                form.append(`<textarea id="model-text-DP-${index}" name="model-text-DP-${index}" rows="8" cols="25">${model.attributes.attrs.text.text}</textarea>`);
+                form.append(`<textarea id="model-text-DP-${index}" name="model-text-DP-${index}" rows="8" cols="25">${propObj.attrs.text.text}</textarea>`);
                 form.append('<br/>');
             });
         }

--- a/public/src/js/tools/ManageTools.js
+++ b/public/src/js/tools/ManageTools.js
@@ -15,6 +15,7 @@ export function addRectTools(element) {
     let rect_tools = [boundaryTool, removeButton, linkButton, editButton];
     //only add dependent premise tool to argument type, not objection
     if (element.attributes.type == "argument") {
+        console.log("adding dp button");
         rect_tools.push(combinedPremiseButton);
     }
     let toolsView = new joint.dia.ToolsView({

--- a/public/src/js/tools/RemoveDependentPremise.js
+++ b/public/src/js/tools/RemoveDependentPremise.js
@@ -36,12 +36,14 @@ joint.elementTools.RemoveDependentPreimseButton = joint.elementTools.Button.exte
         //cast this context to any type, not sure what type it would be otherwise
         action: function () {
             let model = this.model;
-            model.attributes.props.forEach((props) => {
+            let spawn_pos = Object.assign({}, model.attributes.position);
+            const spawn_padding = 10;
+            model.attributes.props.forEach((propObj, index) => {
                 const new_rect = new Argument({
-                    x: props.position.x,
-                    y: props.position.y,
-                    text: props.attrs.text.text,
-                    type: props.type,
+                    x: spawn_pos.x,
+                    y: spawn_pos.y,
+                    text: propObj.attrs.text.text,
+                    type: propObj.type,
                     body_color: color.argument.bodyColor,
                     text_color: color.argument.textColor,
                     stroke: color.argument.stroke,
@@ -50,6 +52,7 @@ joint.elementTools.RemoveDependentPreimseButton = joint.elementTools.Button.exte
                 });
                 new_rect.rect.addTo(graph);
                 addRectTools(new_rect.rect);
+                spawn_pos.x += propObj.size.width + spawn_padding;
             });
             //remove this dependent premise
             model.remove();

--- a/public/src/js/tools/RemoveDependentPremise.js
+++ b/public/src/js/tools/RemoveDependentPremise.js
@@ -1,5 +1,7 @@
 import { graph } from "../graph.js";
 import { addRectTools } from "./ManageTools.js";
+import { Argument } from "../Argument.js";
+import { color } from "../colors.js";
 const joint = window.joint;
 joint.elementTools.RemoveDependentPreimseButton = joint.elementTools.Button.extend({
     name: "remove-dependent-premise-button",
@@ -34,9 +36,20 @@ joint.elementTools.RemoveDependentPreimseButton = joint.elementTools.Button.exte
         //cast this context to any type, not sure what type it would be otherwise
         action: function () {
             let model = this.model;
-            model.attributes.models.forEach((element) => {
-                element.addTo(graph);
-                addRectTools(element);
+            model.attributes.props.forEach((props) => {
+                const new_rect = new Argument({
+                    x: props.position.x,
+                    y: props.position.y,
+                    text: props.attrs.text.text,
+                    type: props.type,
+                    body_color: color.argument.bodyColor,
+                    text_color: color.argument.textColor,
+                    stroke: color.argument.stroke,
+                    link_color: color.argument.linkColor,
+                    weight: "1.0"
+                });
+                new_rect.rect.addTo(graph);
+                addRectTools(new_rect.rect);
             });
             //remove this dependent premise
             model.remove();

--- a/public/src/ts/DependentPremise.ts
+++ b/public/src/ts/DependentPremise.ts
@@ -30,7 +30,7 @@ const DependentPremiseRect = joint.shapes.standard.Rectangle.define(
     link_color: "green",
     weight: "1",
     type: "dependent-premise",
-    models: []
+    props: []
     // ---
   }
 );
@@ -42,8 +42,8 @@ const DependentPremiseRect = joint.shapes.standard.Rectangle.define(
 });
 
 interface DependentPremiseOptions {
-  rect1: joint.shapes.app.CustomRect,
-  rect2: joint.shapes.app.CustomRect,
+  props1: any,
+  props2: any,
   x: number,
   y: number,
   text: string,
@@ -60,37 +60,37 @@ interface DependentPremiseOptions {
 export class DependentPremise {
   rect: joint.shapes.app.DependentPremiseRect
   constructor(config: DependentPremiseOptions) {
-    let rect1 = config.rect1.clone();
-    let rect2 = config.rect2.clone();
+    let props1 = Object.assign({}, config.props1);
+    let props2 = Object.assign({}, config.props2);
 
-    let models: Array<any> = [];
-    if (rect1.attributes.type === "dependent-premise") {
-      models.push(...rect1.attributes.models);
+    let props: Array<any> = [];
+    if (props1.type === "dependent-premise") {
+      props.push(...props1.props);
     }
     else {
-      models.push(rect1);
+      props.push(props1);
     }
-    if (rect2.attributes.type === "dependent-premise") {
-      models.push(...rect2.attributes.models);
+    if (props2.type === "dependent-premise") {
+      props.push(...props2.props);
     }
     else {
-      models.push(rect2);
+      props.push(props2);
     }
 
-    console.log("models", models);
+    console.log("props", props);
 
     //set size
-    let width = rect1.attributes.size.width + rect2.attributes.size.width;
+    let width = props1.size.width + props2.size.width;
     let height = Math.max(
-      rect1.attributes.size.height,
-      rect2.attributes.size.height
+      props1.size.height,
+      props2.size.height
     );
     // set position (average position of two rects)
-    let x = (rect1.attributes.position.x + rect2.attributes.position.x) / 2;
-    let y = (rect1.attributes.position.y + rect2.attributes.position.y) / 2;
+    let x = (props1.position.x + props2.position.x) / 2;
+    let y = (props1.position.y + props2.position.y) / 2;
     //text wrap for both
-    let text_wrap1 = rect1.attributes.attrs.text.text;
-    let text_wrap2 = rect2.attributes.attrs.text.text;
+    let text_wrap1 = props1.attrs.text.text;
+    let text_wrap2 = props2.attrs.text.text;
 
     //generate new text string for display
     let combined_text = combineText(text_wrap1, text_wrap2);
@@ -134,9 +134,9 @@ export class DependentPremise {
       link_color: config.link_color,
       weight: config.weight,
       type: config.type,
-      models: models
+      props: props
     });
-    console.log(this.rect);
+    console.log("NEW DEPENDENT PREMISE", this.rect);
   }
 }
 

--- a/public/src/ts/menu/CreateArguments.ts
+++ b/public/src/ts/menu/CreateArguments.ts
@@ -6,19 +6,20 @@ import { Argument } from '../Argument.js'
 import { DependentPremise } from '../DependentPremise.js';
 
 //when new-argument-button is clicked
-export function createArgument(x:number, y:number, props:any={}) {
+export function createArgument(x:number, y:number) {
   //creating new rect (Joint.js object)
   const new_rect = new Argument({
-    x: props.x || x,
-    y: props.y || y,
-    text: (props.attrs ? props.text.text : (props.text || "Argument") ),
-    type: props.type || "argument",
+    x: x,
+    y: y,
+    text: "Argument",
+    type: "argument",
     body_color: color.argument.bodyColor,
     text_color: color.argument.textColor, 
     stroke: color.argument.stroke,
     link_color: color.argument.linkColor,
     weight: "1.0"
   });
+
   //add new rect to the graph for displaying
   new_rect.rect.addTo(graph);
   //adds the buttons to each rect
@@ -27,19 +28,20 @@ export function createArgument(x:number, y:number, props:any={}) {
 }
 
 //when objection-button is clicked
-export function createObjection(x:number, y:number, props:any={}) {
+export function createObjection(x:number, y:number) {
   //creating new rect (Joint.js object)
   const new_rect = new Argument({
-    x: props.x || x,
-    y: props.y || y,
-    text: props.attrs.text.text || props.text || "Objection",
-    type: props.type || "objection",
+    x: x,
+    y: y,
+    text: "Objection",
+    type: "objection",
     body_color: color.objection.bodyColor,
     text_color: color.objection.textColor,
     stroke: color.objection.stroke, 
     link_color: color.objection.linkColor,
     weight: "-1.0"
   });
+  
   new_rect.rect.addTo(graph);
   //adds the buttons to each rect
   addRectTools(new_rect.rect);
@@ -68,8 +70,6 @@ export function createDependentPremise(rect1: joint.shapes.app.CustomRect, rect2
   new_dependent_premise.rect.addTo(graph);
   //adds the buttons to each rect
   addDependentPremiseTools(new_dependent_premise.rect);
-
-  console.log(new_dependent_premise);
 
   return new_dependent_premise;
 }

--- a/public/src/ts/menu/CreateArguments.ts
+++ b/public/src/ts/menu/CreateArguments.ts
@@ -6,13 +6,13 @@ import { Argument } from '../Argument.js'
 import { DependentPremise } from '../DependentPremise.js';
 
 //when new-argument-button is clicked
-export function createArgument(x:number, y:number) {
+export function createArgument(x:number, y:number, props:any={}) {
   //creating new rect (Joint.js object)
   const new_rect = new Argument({
-    x: x,
-    y: y,
-    text: "Argument",
-    type: "argument",
+    x: props.x || x,
+    y: props.y || y,
+    text: (props.attrs ? props.text.text : (props.text || "Argument") ),
+    type: props.type || "argument",
     body_color: color.argument.bodyColor,
     text_color: color.argument.textColor, 
     stroke: color.argument.stroke,
@@ -27,13 +27,13 @@ export function createArgument(x:number, y:number) {
 }
 
 //when objection-button is clicked
-export function createObjection(x:number, y:number) {
+export function createObjection(x:number, y:number, props:any={}) {
   //creating new rect (Joint.js object)
   const new_rect = new Argument({
-    x: x,
-    y: y,
-    text: "Objection",
-    type: "objection",
+    x: props.x || x,
+    y: props.y || y,
+    text: props.attrs.text.text || props.text || "Objection",
+    type: props.type || "objection",
     body_color: color.objection.bodyColor,
     text_color: color.objection.textColor,
     stroke: color.objection.stroke, 
@@ -50,8 +50,8 @@ export function createObjection(x:number, y:number) {
 export function createDependentPremise(rect1: joint.shapes.app.CustomRect, rect2: joint.shapes.app.CustomRect) {
   //creating new rect (Joint.js object)
   let new_dependent_premise = new DependentPremise({
-    rect1: rect1,
-    rect2: rect2,
+    props1: rect1.attributes,
+    props2: rect2.attributes,
     x: 100,
     y: 100,
     text: "A dependent premise",
@@ -68,5 +68,8 @@ export function createDependentPremise(rect1: joint.shapes.app.CustomRect, rect2
   new_dependent_premise.rect.addTo(graph);
   //adds the buttons to each rect
   addDependentPremiseTools(new_dependent_premise.rect);
+
+  console.log(new_dependent_premise);
+
   return new_dependent_premise;
 }

--- a/public/src/ts/menu/SaveEditsButton.ts
+++ b/public/src/ts/menu/SaveEditsButton.ts
@@ -13,24 +13,22 @@ export function saveEdits() {
 
   if(editModel.attributes.type === "dependent-premise") {
     //save new text and adjust size on each model in dependent premise
-    editModel.attributes.models.forEach((model:Argument['rect'], index:number) => {
-      model.attr('text/text', text_wraps[index]);
-      model.resize(model.attributes.size.width, heights[index]);
-      console.log(model.attributes.attrs.text.text);
+    editModel.attributes.props.forEach((propObj:any, index:number) => {
+      propObj.attrs.text.text = text_wraps[index];
+      propObj.size.height = heights[index];
     });
-      let max_height = Math.max(...heights);
-      //the 36 is dependent on font-size!!
-      let width = 36 + editModel.attributes.models.reduce((total:number, model:Argument['rect']) => total + model.attributes.size.width, 0);
-      let combinedText = text_wraps.slice(1).reduce((total:string, current:string) => {
-        //skip first one
-        return combineText(total, current);
-      }, text_wraps[0]);
-      //let combinedText = combineText(left_wrap, right_wrap);
 
-      editModel.attr('text/text', combinedText)
-      editModel.resize(width, max_height);
-      // console.log((height/16) - 1)
-      console.log("new_text", editModel.attributes.attrs.text.text)
+    let max_height = Math.max(...heights);
+    //the 36 is dependent on font-size!!
+    let width = 36 + editModel.attributes.props.reduce((total:number, propObj:any) => total + propObj.size.width, 0);
+    let combinedText = text_wraps.slice(1).reduce((total:string, current:string) => {
+      return combineText(total, current);
+    }, text_wraps[0]);
+
+    editModel.attr('text/text', combinedText)
+    editModel.resize(width, max_height);
+    // console.log((height/16) - 1)
+    console.log("new_text", editModel.attributes.attrs.text.text)
   }
   else {
     //just update the single model with the new text and size

--- a/public/src/ts/tools/EditButton.ts
+++ b/public/src/ts/tools/EditButton.ts
@@ -119,9 +119,9 @@ joint.elementTools.EditDependentPremiseButton = joint.elementTools.Button.extend
       const form = $('#edit-form');
       form.empty();
 
-      editModel.attributes.models.forEach((model:Argument['rect'], index:number) => {
+      editModel.attributes.props.forEach((propObj:any, index:number) => {
         form.append(`<label class="menu-text">Edit Argument ${index+1} Text:</label>`);
-        form.append(`<textarea id="model-text-DP-${index}" name="model-text-DP-${index}" rows="8" cols="25">${model.attributes.attrs.text.text}</textarea>`);
+        form.append(`<textarea id="model-text-DP-${index}" name="model-text-DP-${index}" rows="8" cols="25">${propObj.attrs.text.text}</textarea>`);
         form.append('<br/>');
       });
     }  

--- a/public/src/ts/tools/ManageTools.ts
+++ b/public/src/ts/tools/ManageTools.ts
@@ -19,6 +19,7 @@ export function addRectTools(element: joint.shapes.app.CustomRect) {
 
   //only add dependent premise tool to argument type, not objection
   if (element.attributes.type == "argument") {
+    console.log("adding dp button");
     rect_tools.push(combinedPremiseButton);
   }
 

--- a/public/src/ts/tools/RemoveDependentPremise.ts
+++ b/public/src/ts/tools/RemoveDependentPremise.ts
@@ -3,6 +3,7 @@ import { elementTools } from "jointjs"
 import { graph } from "../graph.js"
 import { addRectTools, addDependentPremiseTools } from "./ManageTools.js"
 import { Argument } from "../Argument.js"
+import { color } from "../colors.js" 
 
 const joint = window.joint
 
@@ -48,9 +49,20 @@ joint.elementTools.RemoveDependentPreimseButton = joint.elementTools.Button.exte
       action: function (this:any) {
         let model = this.model;
 
-        model.attributes.models.forEach((element:Argument['rect']) => {
-          element.addTo(graph);
-          addRectTools(element);
+        model.attributes.props.forEach((props:any) => {
+          const new_rect = new Argument({
+            x: props.position.x,
+            y: props.position.y,
+            text: props.attrs.text.text,
+            type: props.type,
+            body_color: color.argument.bodyColor,
+            text_color: color.argument.textColor, 
+            stroke: color.argument.stroke,
+            link_color: color.argument.linkColor,
+            weight: "1.0"
+          });
+          new_rect.rect.addTo(graph);
+          addRectTools(new_rect.rect);
           
         });
 

--- a/public/src/ts/tools/RemoveDependentPremise.ts
+++ b/public/src/ts/tools/RemoveDependentPremise.ts
@@ -49,20 +49,25 @@ joint.elementTools.RemoveDependentPreimseButton = joint.elementTools.Button.exte
       action: function (this:any) {
         let model = this.model;
 
-        model.attributes.props.forEach((props:any) => {
+        let spawn_pos = Object.assign({}, model.attributes.position);
+        const spawn_padding = 10;
+        model.attributes.props.forEach((propObj:any, index:number) => {
           const new_rect = new Argument({
-            x: props.position.x,
-            y: props.position.y,
-            text: props.attrs.text.text,
-            type: props.type,
+            x: spawn_pos.x,
+            y: spawn_pos.y,
+            text: propObj.attrs.text.text,
+            type: propObj.type,
             body_color: color.argument.bodyColor,
             text_color: color.argument.textColor, 
             stroke: color.argument.stroke,
             link_color: color.argument.linkColor,
             weight: "1.0"
           });
+
           new_rect.rect.addTo(graph);
           addRectTools(new_rect.rect);
+
+          spawn_pos.x += propObj.size.width + spawn_padding;
           
         });
 


### PR DESCRIPTION
Fixes circular structure caused by dependent premises. Instead of storing the entire model in a ```models``` array which causes the circular structure, we just store the attributes object in a ```props``` array. 

Also, when destroying a dependent premise, the premises will spawn spread out around where the dependent premise was destroyed. However, since we can't move the paper right now, it is possible for these to spawn off screen so this will have to get improved later.