### PR TITLE
Dp & link bug fixes

### DIFF
--- a/public/src/js/DependentPremise.js
+++ b/public/src/js/DependentPremise.js
@@ -1,8 +1,9 @@
 /* global joint */
 const joint = window.joint;
 import { color } from "./colors.js";
-import { paper } from "./graph.js";
+import { graph, paper } from "./graph.js";
 import { addRectTools } from "./tools/ManageTools.js";
+import { selected_links } from "./tools/LinkButton.js";
 //custom shape declaration for DependentPremise
 const DependentPremiseRect = joint.shapes.standard.Rectangle.define("app.DependentPremise", {
     markup: '<g class="rotatable"><g class="scalable"><rect/></g><text/></g>',
@@ -104,6 +105,19 @@ export class DependentPremise {
             };
             //update tools
             addRectTools(models[i]);
+            //remove outgoing links
+            let links = graph.getConnectedLinks(models[i], { outbound: true });
+            links.forEach(link => {
+                link.remove();
+            });
+            //remove from link selection if applicable
+            if (selected_links[0]) {
+                if (selected_links[0] === models[i]) {
+                    joint.dia.HighlighterView.remove(models[i].findView(paper), 'link-highlight');
+                    //alternate way to clear array that gets around typescript import restrictions
+                    selected_links.splice(0, selected_links.length);
+                }
+            }
         }
         console.log("NEW DEPENDENT PREMISE", this.rect);
         if (rect1.attributes.type === "dependent-premise") {

--- a/public/src/js/tools/LinkButton.js
+++ b/public/src/js/tools/LinkButton.js
@@ -37,6 +37,8 @@ joint.elementTools.LinkButton = joint.elementTools.Button.extend({
         action: function () {
             let elementView = this.model.findView(paper);
             // this is where the actual function of the button goes (onclick event basically)
+            console.log('linking mode active');
+            //linking mode active
             selected_links.push(this.model);
             if (selected_links.length === 1) {
                 if (selected_links[0].get('parent')) {

--- a/public/src/js/tools/LinkButton.js
+++ b/public/src/js/tools/LinkButton.js
@@ -62,7 +62,6 @@ joint.elementTools.LinkButton = joint.elementTools.Button.extend({
                 //check if two models are the same model
                 if (selected_links[0].id !== selected_links[1].id) {
                     createLink(selected_links[0], selected_links[1]);
-                    console.log("link made");
                 }
                 joint.dia.HighlighterView.remove(elementView, 'link-highlight');
                 selected_links = [];
@@ -74,6 +73,11 @@ joint.elementTools.LinkButton = joint.elementTools.Button.extend({
 //link two rects together
 export function createLink(model1, model2) {
     console.log(model1.attributes.link_color);
+    //prevent dp from linking to one of its children
+    if (model2.get('parent') && graph.getCell(model2.get("parent")) === model1) {
+        console.log("ERROR: Dependent premise can not link to one of its own embeded children");
+        return;
+    }
     //passes in Claim objects
     let link = new joint.shapes.standard.Link();
     link.source(model1);
@@ -103,6 +107,7 @@ export function createLink(model1, model2) {
     //link rects on graph
     console.log(link);
     link.addTo(graph);
+    console.log("link made");
     addLinkTools(link);
     //remove highlights from models
     let linkView1 = model1.findView(paper);

--- a/public/src/ts/DependentPremise.ts
+++ b/public/src/ts/DependentPremise.ts
@@ -2,8 +2,10 @@
 const joint = window.joint;
 
 import { color } from "./colors.js"
-import { paper } from "./graph.js";
+import { graph, paper } from "./graph.js";
 import { addRectTools } from "./tools/ManageTools.js"
+import { selected_links } from "./tools/LinkButton.js"
+import { selected_premises } from "./tools/CombinePremise.js";
 
 declare module "jointjs" {
   namespace shapes {
@@ -145,6 +147,21 @@ export class DependentPremise {
       }
       //update tools
       addRectTools(models[i]);
+
+      //remove outgoing links
+      let links = graph.getConnectedLinks(models[i], {outbound: true})
+      links.forEach(link => {
+        link.remove();
+      });
+
+      //remove from link selection if applicable
+      if (selected_links[0]) {
+        if (selected_links[0] === models[i]) {
+          joint.dia.HighlighterView.remove(models[i].findView(paper), 'link-highlight')
+          //alternate way to clear array that gets around typescript import restrictions
+          selected_links.splice(0,selected_links.length);
+        }
+      }
     }
 
     console.log("NEW DEPENDENT PREMISE", this.rect);

--- a/public/src/ts/tools/LinkButton.ts
+++ b/public/src/ts/tools/LinkButton.ts
@@ -91,10 +91,12 @@ joint.elementTools.LinkButton = joint.elementTools.Button.extend({
 //link two rects together
 export function createLink(model1:joint.shapes.app.ClaimRect, model2:joint.shapes.app.ClaimRect) {
   console.log(model1.attributes.link_color);
+
   //passes in Claim objects
   let link = new joint.shapes.standard.Link();
   link.source(model1);
   link.target(model2);
+
   //link attributes based on arg1/rect1 (source)
   link.attr({
     line: {

--- a/public/src/ts/tools/LinkButton.ts
+++ b/public/src/ts/tools/LinkButton.ts
@@ -78,7 +78,6 @@ joint.elementTools.LinkButton = joint.elementTools.Button.extend({
         //check if two models are the same model
         if (selected_links[0].id !== selected_links[1].id) {
           createLink(selected_links[0], selected_links[1]);
-          console.log("link made")
         }
         joint.dia.HighlighterView.remove(elementView, 'link-highlight')
         selected_links = [];
@@ -91,6 +90,12 @@ joint.elementTools.LinkButton = joint.elementTools.Button.extend({
 //link two rects together
 export function createLink(model1:joint.shapes.app.ClaimRect, model2:joint.shapes.app.ClaimRect) {
   console.log(model1.attributes.link_color);
+
+  //prevent dp from linking to one of its children
+  if (model2.get('parent') && graph.getCell(model2.get("parent")) === model1 ) {
+    console.log("ERROR: Dependent premise can not link to one of its own embeded children")
+    return;
+  }
 
   //passes in Claim objects
   let link = new joint.shapes.standard.Link();
@@ -122,6 +127,7 @@ export function createLink(model1:joint.shapes.app.ClaimRect, model2:joint.shape
   //link rects on graph
   console.log(link);
   link.addTo(graph);
+  console.log("link made")
   addLinkTools(link);
 
   //remove highlights from models


### PR DESCRIPTION
Fixed a number of bugs related to new DP and related links

- Claims added to a dp have outgoing links removed. This serves both as a relevant fix to dp behavior in general, and also helps to prevent claims within the same dp from linking to one another.
- When creating a link, a check is done to prevent a dependent premise from linking to one of its own embedded children.