### PR TITLE
invalid linking now only removes target

### DIFF
--- a/public/src/js/tools/LinkButton.js
+++ b/public/src/js/tools/LinkButton.js
@@ -71,6 +71,10 @@ joint.elementTools.LinkButton = joint.elementTools.Button.extend({
                 if (isValidLink(selected_links[0], selected_links[1])) {
                     createLink(selected_links[0], selected_links[1]);
                 }
+                else {
+                    joint.dia.HighlighterView.remove(selected_links[1].findView(paper), 'link-highlight');
+                    selected_links.pop();
+                }
                 joint.dia.HighlighterView.remove(elementView, 'link-highlight');
                 joint.dia.HighlighterView.remove(selected_links[1].findView(paper), 'link-highlight');
                 selected_links = [];

--- a/public/src/ts/tools/LinkButton.ts
+++ b/public/src/ts/tools/LinkButton.ts
@@ -86,6 +86,9 @@ joint.elementTools.LinkButton = joint.elementTools.Button.extend({
         //check if two models are the same model
         if (isValidLink(selected_links[0], selected_links[1])) {
           createLink(selected_links[0], selected_links[1]);
+        } else {
+          joint.dia.HighlighterView.remove(selected_links[1].findView(paper), 'link-highlight');
+          selected_links.pop();
         }
         joint.dia.HighlighterView.remove(elementView, 'link-highlight');
         joint.dia.HighlighterView.remove(selected_links[1].findView(paper), 'link-highlight');


### PR DESCRIPTION
Previously, if you made a circular argument the highlight around the intended source would not be removed, even though it was no longer part of the selected links array.